### PR TITLE
Fix log_switch dependency

### DIFF
--- a/rtsp.gemspec
+++ b/rtsp.gemspec
@@ -28,6 +28,7 @@ http://www.ietf.org/rfc/rfc2326.txt}
   s.add_runtime_dependency 'parslet', '>= 1.1.0'
   s.add_runtime_dependency 'rtp', '>= 0.1.3'
   s.add_runtime_dependency 'sdp', '~> 0.2.6'
+  s.add_runtime_dependency 'log_switch', '~> 0.4.0'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'cucumber', '>= 1.1.0'


### PR DESCRIPTION
This PR will fix issue #25. `log_switch` 1.0.0 is not compatible with `rtsp`. Adding `log_switch ~> 0.4.0` dependency.